### PR TITLE
Pinned the black version to 21.7b0 (was causing issues when installing)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 setup_requirements = [
-    "black ~= 21.6b0",
+    "black == 21.7b0",
     "flake8 ~= 3.9",
     "isort ~= 5.9",
     "mypy ~= 0.910",


### PR DESCRIPTION
Small fix to pin black to 21.7b0 (was causing issues when installing venv)