### PR TITLE
Changed crop-dims to 1800x1200

### DIFF
--- a/camera_alignment_core/constants.py
+++ b/camera_alignment_core/constants.py
@@ -37,17 +37,18 @@ class Magnification(enum.Enum):
             # The steps by which these dimensions were determined are unknown--they are "inherited constants."
             return CroppingDimension(900, 600)
         elif self == Magnification.SIXTY_THREE:
-            # The cropping dimensions for 63x and 20x were determined by Filip on 8/19/2021 via following steps:
-            #   - Look through a sample of ZSD images at each magnification to determine the minimum FOV dimensions. In both cases it was 1848x1248.
-            #   - Open a minimum-size image with a brightfield channel in FIJI and duplicate one slice of the bright channel.
-            #   - Apply a translation in x and y and a rotation to the image that corresponds to the **assumed worst-case misalignment**:
-            #       - Assumed that the microscope user/bead aligner made a decent attempt to visually align the cameras visually
-            #       - Applied a translation of **5 pixels in both x and y** and a **rotation of 0.5 degrees**
-            #   - Use the line tool to measure the length of the largest regions of black pixels in the resulting image along each axis
-            #   - Multiply those numbers by 2 and subtract from the minimum dimensions
-            #   Found that 6.3% of image was cropped in 100X (using 924x624 to 900x600). Kept this constant for 63X and 20X to get 1800x1200
-            #   Argolight images that were analyzed were shown to have no black pixels once cropped with these dimensions,
-            #   other than 5 outliers which would be failed.
+            # The cropping dimensions for 63x and 20x were agreed upon by the microscopy committee on 9/4/2021:
+            #   - Ran 180 argolight field of ring images through the generate_alignment_matrix code
+            #   - From the metrics generated from that script, plotted what the crop dimensions would be for each
+            #   argolight images such that no black pixels would exist in the image after alignment ("perfect" crop)
+            #   - Proceeded to look at how much area was lost due to the above cropping, and plotted this as well
+            #   - Matched the area lost from the normal cropping in 100X (~6.3%), and saw how many "perfect" crops
+            #   would fall above or below that threshold
+            #   - Saw that only 5 of the 180 would wall above the 6.3% area lost when cropped "perfectly"
+            #   - Went through these 5 outliers and saw that there were issues with segmentations/SNR/physical
+            #   alignment, shwoing that we should fail the outliers.
+            #   - Agreed that the dimensions that allow loss of 6.3% of total area (1800x1200) for 20X and 63X
+            #   were most suitable for default cropping dimensions
             return CroppingDimension(1800, 1200)
         elif self == Magnification.TWENTY:
             # See notes re 63X magnification for process by which these cropping dimensions were determined


### PR DESCRIPTION
From discussion with assay-dev and microscopy, we are going with 1800x1200 for crop dims for 63x and 20x images.

**Pull request recommendations:**
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
