### PR TITLE
Add Channel.from_wavelength utility

### DIFF
--- a/camera_alignment_core/constants.py
+++ b/camera_alignment_core/constants.py
@@ -14,14 +14,14 @@ class Channel(enum.Enum):
     RAW_638_NM = "Raw 638nm"
 
     @staticmethod
-    def from_magnification(nominal_magnification: int) -> "Channel":
-        """Return canonical Channel enumeration corresponding to given nominal_magnification.
+    def from_wavelength(wavelength: int) -> "Channel":
+        """Return canonical Channel enumeration corresponding to given wavelength.
 
-        Notably, this method does not attempt to support brightfield: it only maps nominal magnifications to Channel instances.
+        Notably, this method does not attempt to support brightfield: it only maps wavelengths to Channel instances.
 
         Parameters
         ----------
-        nominal_magnification : int
+        wavelength : int
 
         Returns
         -------
@@ -30,7 +30,7 @@ class Channel(enum.Enum):
         Raises
         ------
         ValueError
-            If given nominal_magnification does not correspond to a known Channel.
+            If given wavelength does not correspond to a known Channel.
         """
         mapping = {
             405: Channel.RAW_405_NM,
@@ -39,10 +39,10 @@ class Channel(enum.Enum):
             638: Channel.RAW_638_NM,
         }
 
-        channel = mapping.get(nominal_magnification)
+        channel = mapping.get(wavelength)
         if not channel:
             raise ValueError(
-                f"Unsupported nominal_magnification: {nominal_magnification}. Supported values: {mapping.keys()}."
+                f"Unsupported wavelength: {wavelength}. Supported values: {mapping.keys()}."
             )
 
         return channel

--- a/camera_alignment_core/tests/test_constants.py
+++ b/camera_alignment_core/tests/test_constants.py
@@ -6,7 +6,7 @@ from camera_alignment_core.constants import (
 
 
 @pytest.mark.parametrize(
-    ["nominal_magnification", "expected"],
+    ["wavelength", "expected"],
     [
         (405, Channel.RAW_405_NM),
         (488, Channel.RAW_488_NM),
@@ -15,11 +15,9 @@ from camera_alignment_core.constants import (
         pytest.param(999, None, marks=pytest.mark.xfail(raises=ValueError)),
     ],
 )
-def test_channel_from_magnification(
-    nominal_magnification: int, expected: Channel
-) -> None:
+def test_channel_from_wavelength(wavelength: int, expected: Channel) -> None:
     # Arrange / Act
-    actual = Channel.from_magnification(nominal_magnification)
+    actual = Channel.from_wavelength(wavelength)
 
     # Assert
     assert actual == expected


### PR DESCRIPTION
This adds a static method to the `Channel` enum for returning the relevant enumeration instance for a given wavelength.

In the course of integrating this with the camera-alignment-service, I found myself wanting this method. Instead of writing it in that service, I put it here so that it's more widely available.
