### PR TITLE
Fix type checking issues

### DIFF
--- a/camera_alignment_core/align.py
+++ b/camera_alignment_core/align.py
@@ -104,6 +104,7 @@ class Align:
         Get the similarity matrix and camera_alignment_core.utils.AlignmentInfo used to perform camera alignment.
         """
         if self._alignment_matrix is None or self._alignment_info is None:
+            assert self._optical_control.physical_pixel_sizes.X is not None
             assert (
                 self._optical_control.physical_pixel_sizes.X
                 == self._optical_control.physical_pixel_sizes.Y

--- a/camera_alignment_core/tests/test_alignment_core.py
+++ b/camera_alignment_core/tests/test_alignment_core.py
@@ -128,6 +128,10 @@ class TestAlignmentCore:
         optical_control_image, _ = get_test_image(alignment_image_path)
         optical_control_image_data = optical_control_image.get_image_data("CZYX", T=0)
 
+        # Properties of aicsimageio's PhysicalPixelSizes are typed as Optional,
+        # so assert the `X` property `is not None` before use in `generate_alignment_matrix`
+        assert optical_control_image.physical_pixel_sizes.X is not None
+
         (alignment_matrix, _,) = generate_alignment_matrix(
             optical_control_image=optical_control_image_data,
             # TaRFP should have been used instead,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from setuptools import find_packages, setup
 
 
 requirements = [
-    "aicsimageio ~= 4.4",
+    # Ideally, would specify `aicsimageio ~= 4.7` or similar (note no match on patch version),
+    # but the Dimensions object is not properly typed and > 4.7 ships with a `py.typed` file.
+    # Once this is fixed in aicsimageio, this restrictive version-range can be loosened.
+    "aicsimageio ~= 4.7.0",
     "aicspylibczi ~= 3.0.0",
     "numpy ~= 1.21",
     "scikit-image ~= 0.18"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ requirements = [
     "aicsimageio ~= 4.7.0",
     "aicspylibczi ~= 3.0.0",
     "numpy ~= 1.21",
-    "scikit-image ~= 0.18"
+
+    # v0.19.3 causes test failure for TestAlignmentCore::test_align_image
+    "scikit-image == 0.19.2"
 ]
 
 dev_requirements = [


### PR DESCRIPTION
**Context:**
@benjijamorris Discovered some issues on `main` with type checking that have been visible in CI for some time. These issues surfaced due to `aicsimageio` now shipping type annotations as part of the library, since v4.8. While two typing problems could be fixed in this repo by adding some `is not None` assertions to narrow `Optional` types, there are additional problems related to property access on `aicsimageio`'s `Dimensions` class that need to be fixed in upstream. 

**This changeset:**
- Fix the typing issues we have control over in this repo.
- To get this library building again and unblock Benji, this PR pins `aicsimageio` to the 4.7.X version range.