### PR TITLE
20x alignment fixes and tests

### DIFF
--- a/camera_alignment_core/alignment_utils/segment_rings.py
+++ b/camera_alignment_core/alignment_utils/segment_rings.py
@@ -47,7 +47,7 @@ class SegmentRings:
             self.thresh = (0.5, 99.5)
 
     def dot_2d_slice_by_slice_wrapper(
-        self, struct_img: np.typing.NDArray[np.uint16], s2_param: List
+        self, struct_img: np.typing.NDArray[np.float32], s2_param: List
     ) -> np.typing.NDArray[np.bool_]:
         """
         https://github.com/AllenCell/aics-segmentation/blob/main/aicssegmentation/core/seg_dot.py
@@ -197,7 +197,7 @@ class SegmentRings:
         thresh: filter parameter after optimization
 
         """
-        img = np.zeros((1, img_2d.shape[0], img_2d.shape[1]), dtype=np.uint16)
+        img = np.zeros((1, img_2d.shape[0], img_2d.shape[1]), dtype=np.float32)
         img[0, :, :] = img_2d
 
         thresh = None

--- a/camera_alignment_core/tests/__init__.py
+++ b/camera_alignment_core/tests/__init__.py
@@ -17,6 +17,9 @@ log = logging.getLogger(LOGGER_NAME)
 # Taken from /allen/aics/microscopy/PRODUCTION/OpticalControl/ArgoLight/Argo_QC_Daily/ZSD1/ZSD1_argo_100X_SLF-015_20210624   # noqa E501
 ZSD_100x_OPTICAL_CONTROL_IMAGE_URL = "https://s3.us-west-2.amazonaws.com/public-dev-objects.allencell.org/camera-alignment-core/optical-controls/argo_ZSD1_100X_SLF-015_20210624.czi"  # noqa E501
 
+# Taken from //allen/aics/microscopy/PRODUCTION/OpticalControl/ArgoLight/Argo_QC_Daily/ZSD1/ZSD1_argo_20X_SLG-506_20220510/ZSD1_argo_20X_SLG-506_20220510.czi   # noqa E501
+ZSD_20x_OPTICAL_CONTROL_IMAGE_URL = "https://s3.us-west-2.amazonaws.com/public-dev-objects.allencell.org/camera-alignment-core/optical-controls/ZSD1_argo_20X_SLG-506_20220510.czi"  # noqa E501
+
 # FMS ID: 0023c446cd384dc3947c90dc7a76f794; 303.38 MB
 GENERIC_OME_TIFF_URL = "https://s3.us-west-2.amazonaws.com/public-dev-objects.allencell.org/camera-alignment-core/images/3500003897_100X_20200306_1r-Scene-30-P89-G11.ome.tiff"  # noqa E501
 

--- a/camera_alignment_core/tests/test_alignment_core.py
+++ b/camera_alignment_core/tests/test_alignment_core.py
@@ -27,6 +27,7 @@ from . import (
     ALIGNED_ZSD1_IMAGE_URL,
     ARGOLIGHT_OPTICAL_CONTROL_IMAGE_URL,
     UNALIGNED_ZSD1_IMAGE_URL,
+    ZSD_20x_OPTICAL_CONTROL_IMAGE_URL,
     ZSD_100x_OPTICAL_CONTROL_IMAGE_URL,
     get_test_image,
 )
@@ -54,6 +55,37 @@ class TestAlignmentCore:
             reference_channel=2,  # TaRFP
             shift_channel=3,  # CMDRP
             magnification=Magnification.ONE_HUNDRED.value,
+            px_size_xy=optical_control_image.physical_pixel_sizes.X,
+        )
+
+        # Assert
+        assert actual_alignment_matrix.shape == expected_matrix.shape
+
+        # Due to inherent challenges with floating point precision across different environments,
+        # compare actual vs expected elementwise with a (very) small epsilon (i.e., allowed error margin)
+        assert numpy.allclose(actual_alignment_matrix, expected_matrix, atol=1e-14), (
+            actual_alignment_matrix - expected_matrix
+        )
+
+    def test_generate_alignment_matrix_20x(self):
+        # Arrange
+        optical_control_image, _ = get_test_image(ZSD_20x_OPTICAL_CONTROL_IMAGE_URL)
+        optical_control_image_data = optical_control_image.get_image_data("CZYX", T=0)
+
+        expected_matrix = numpy.array(
+            [
+                [1.00122588e00, -3.02161488e-03, 1.91048540e00],
+                [3.02161488e-03, 1.00122588e00, -4.75823245e00],
+                [0.00000000e00, 0.00000000e00, 1.00000000e00],
+            ]
+        )
+
+        # Act
+        (actual_alignment_matrix, _,) = generate_alignment_matrix(
+            optical_control_image_data,
+            reference_channel=2,  # TaRFP
+            shift_channel=3,  # CMDRP
+            magnification=Magnification.TWENTY.value,
             px_size_xy=optical_control_image.physical_pixel_sizes.X,
         )
 


### PR DESCRIPTION
**Pull request recommendations:**
- [x ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ x] Provide context of changes.
- [x ] Provide relevant tests for your feature or bug fix.
- [ x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

This fixes a bug in 20x alignment that results in generation of all-nan alignment matrices regardless of input.  
