### PR TITLE
More Robust Argolight Bead Matching Algorithm

### DIFF
--- a/camera_alignment_core/alignment_core.py
+++ b/camera_alignment_core/alignment_core.py
@@ -29,7 +29,6 @@ def generate_alignment_matrix(
     magnification: int,
     px_size_xy: float,
 ) -> Tuple[numpy.typing.NDArray[numpy.float16], AlignmentInfo]:
-
     log.debug(
         "Params -- reference_channel: %s; shift_channel: %s; magnification: %s; px_size_xy: %s",
         reference_channel,

--- a/camera_alignment_core/alignment_utils/alignment_qc.py
+++ b/camera_alignment_core/alignment_utils/alignment_qc.py
@@ -1,0 +1,364 @@
+import logging
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.spatial import distance
+from skimage import metrics
+from skimage import transform as tf
+
+from ..constants import LOGGER_NAME
+from .get_center_z import get_center_z
+
+log = logging.getLogger(LOGGER_NAME)
+
+
+class AlignmentQC:
+    def __init__(
+        self,
+        reference: NDArray[np.uint16] = None,
+        moving: NDArray[np.uint16] = None,
+        reference_seg: NDArray[np.uint16] = None,
+        moving_seg: NDArray[np.uint16] = None,
+        ref_mov_coor_dict: Dict[Tuple[int, int], Tuple[int, int]] = None,
+        rev_coor_dict: Dict[Tuple[int, int], Tuple[int, int]] = None,
+        tform: tf.SimilarityTransform = None,
+    ):
+        self.reference = reference
+        self.moving_source = moving
+
+        if reference is not None:
+            self.ref_origin = get_center_z(reference)
+        else:
+            self.ref_origin = 0
+        if moving is not None:
+            self.mov_origin = get_center_z(moving)
+        else:
+            self.mov_origin = 0
+
+        self.reference_seg = reference_seg
+        self.moving_seg = moving_seg
+
+        self.ref_mov_coor_dict = ref_mov_coor_dict
+        self.rev_coor_dict = rev_coor_dict
+
+        if moving is not None and tform is not None:
+            self.moving_transformed = tf.warp(moving, inverse_map=tform, order=3)
+        else:
+            self.moving_transformed = None
+        if self.moving_seg is not None and tform is not None:
+            self.moving_seg_transformed = tf.warp(
+                moving_seg, inverse_map=tform, order=0, preserve_range=True
+            ).astype(np.uint16)
+        else:
+            self.moving_seg_transformed = None
+        self.tform = tform
+
+    # Full QC ################################################################
+
+    def report_full_metrics(
+        self,
+    ) -> Dict[str, Optional[object]]:
+
+        missing = self.check_all_defined()
+        if missing is not None:
+            log.error(
+                "Error: the following variables have not been set - "
+                + ",".join(missing)
+            )
+
+        z_offset, ref_origin, mov_origin = self.check_z_offset_between_ref_mov()
+        ref_signal, ref_noise, mov_signal, mov_noise = self.report_ref_mov_image_snr()
+        bead_num_qc, num_beads = self.report_number_beads()
+        change_fov_intensity_param_dict = self.report_change_fov_intensity_parameters()
+        coor_dist_qc, diff_sum_beads = self.report_changes_in_coordinates_mapping()
+        mse_qc, diff_mse = self.report_changes_in_mse()
+
+        qc_metrics = {
+            "z_offset": z_offset,
+            "reference_mid_z": ref_origin,
+            "moving_mid_z": mov_origin,
+            "reference_signal": ref_signal,
+            "reference_noise": ref_noise,
+            "moving_signal": mov_signal,
+            "moving_noise": mov_noise,
+            "bead_qc": bead_num_qc,
+            "num_beads": num_beads,
+            "change_fov_intensity_param_dict": change_fov_intensity_param_dict,
+            "coor_dist_qc": coor_dist_qc,
+            "diff_sum_beads": diff_sum_beads,
+            "mse_qc": mse_qc,
+            "diff_mse": diff_mse,
+        }
+
+        return qc_metrics
+
+    # Set individual variables ################################################
+
+    def set_raw_images(
+        self,
+        reference: NDArray[np.uint16],
+        moving: NDArray[np.uint16],
+    ):
+        self.reference = reference
+        self.moving_source = moving
+
+        self.ref_origin = get_center_z(self.reference)
+        self.mov_origin = get_center_z(self.moving_source)
+
+        return
+
+    def set_seg_images(
+        self,
+        reference_seg: NDArray[np.uint16],
+        moving_seg: NDArray[np.uint16],
+    ):
+        self.reference_seg = reference_seg
+        self.moving_seg = moving_seg
+        return
+
+    def set_ref_mov_coor_dict(
+        self,
+        ref_mov_coor_dict: Dict[Tuple[int, int], Tuple[int, int]],
+    ):
+        self.ref_mov_coor_dict = ref_mov_coor_dict
+        return
+
+    def set_rev_coor_dict(
+        self,
+        rev_coor_dict: Dict[Tuple[int, int], Tuple[int, int]],
+    ):
+        self.rev_coor_dict = rev_coor_dict
+        return
+
+    def set_tform(
+        self,
+        tform: tf.SimilarityTransform,
+    ):
+        self.tform = tform
+        if self.moving_source is not None:
+            log.info("Applying transform to current source image")
+            self.moving_transformed = tf.warp(
+                self.moving_source[self.mov_origin], inverse_map=tform, order=3
+            )
+        else:
+            log.warning(
+                "Moving source is not yet defined. Please define and run apply_transform() before qc"
+            )
+        if self.moving_seg is not None:
+            log.info("Applying transform to current source image")
+            self.moving_seg_transformed = tf.warp(
+                self.moving_seg, inverse_map=tform, order=0, preserve_range=True
+            )
+        else:
+            log.warning(
+                "Moving seg is not yet defined. Please define and run apply_transform() before qc"
+            )
+
+    def apply_transform(self):
+        if self.tform is not None:
+            self.moving_transformed = tf.warp(
+                self.moving_source[self.mov_origin], inverse_map=self.tform, order=3
+            )
+            self.moving_seg_transformed = tf.warp(
+                self.moving_seg, inverse_map=self.tform, order=0, preserve_range=True
+            )
+        else:
+            log.error("Error: tform is not yet defined")
+
+    def check_all_defined(self) -> Optional[list[str]]:
+        missing = []
+
+        if self.reference is None:
+            missing.append("source image")
+        if self.moving_source is None:
+            missing.append("moving source")
+        if self.reference_seg is None:
+            missing.append("reference seg")
+        if self.moving_seg is None:
+            missing.append("moving seg")
+        if self.ref_mov_coor_dict is None:
+            missing.append("reference moving coordinate dict")
+        if self.rev_coor_dict is None:
+            missing.append("ref coordinate dict")
+        if self.moving_transformed is None:
+            missing.append("moving transformed")
+        if self.moving_seg_transformed is None:
+            missing.append("moving seg transformed")
+        if self.tform is None:
+            missing.append("transformation")
+
+        if len(missing) == 0:
+            return None
+        else:
+            return missing
+
+    # QC Functions ############################################################
+
+    def check_z_offset_between_ref_mov(self) -> Tuple[int, int, int]:
+        if self.reference is None or self.moving_source is None:
+            log.error("Error: Raw images are missing for qc")
+            raise Exception("Error: Raw images are missing for qc")
+            return -1, -1, -1
+
+        z_offset = self.ref_origin - self.mov_origin
+
+        return z_offset, self.ref_origin, self.mov_origin
+
+    def report_ref_mov_image_snr(self) -> Tuple[int, int, int, int]:
+        if self.reference is None or self.moving_source is None:
+            log.error("Error: Seg images are missing for qc")
+            raise Exception("Error: Seg images are missing for qc")
+            return -1, -1, -1, -1
+
+        def get_image_snr(
+            seg: Optional[NDArray[np.uint16]],
+            img_intensity: Optional[NDArray[np.uint16]],
+        ) -> Tuple[int, int]:
+            if seg is None or img_intensity is None:
+                return -1, -1
+            signal = np.median(img_intensity[seg.astype(bool)])
+            noise = np.median(img_intensity[~seg.astype(bool)])
+
+            return signal, noise
+
+        ref_signal, ref_noise = get_image_snr(
+            self.reference_seg, self.reference[self.ref_origin]
+        )
+        mov_signal, mov_noise = get_image_snr(
+            self.moving_seg, self.moving_source[self.mov_origin]
+        )
+
+        return ref_signal, ref_noise, mov_signal, mov_noise
+
+    def report_number_beads(self) -> Tuple[bool, int]:
+        if self.ref_mov_coor_dict is None:
+            log.error("Error: ref_mov_coor_dict is missing for qc")
+            raise Exception("Error: ref_mov_coor_dict is missing for qc")
+            return False, -1
+
+        bead_num_qc = False
+        num_beads = len(self.ref_mov_coor_dict)
+        if num_beads >= 10:
+            bead_num_qc = True
+        return bead_num_qc, num_beads
+
+    def report_change_fov_intensity_parameters(self) -> Dict[str, int]:
+        """
+        Reports changes in FOV intensity after transform
+        :return: A dictionary with the following keys and values:
+            median_intensity
+            min_intensity
+            max_intensity
+            1_percentile: first percentile intensity
+            995th_percentile: 99.5th percentile intensity
+        """
+        if self.moving_transformed is None or self.moving_source is None:
+            log.error("Error: moving source and transformed images are missing for qc")
+            raise Exception(
+                "Error: moving source and transformed images are missing for qc"
+            )
+            return {"ERROR": -1}
+
+        change_fov_intensity_param_dict = {
+            "median_intensity": np.median(self.moving_transformed) * 65535
+            - np.median(self.moving_source[self.mov_origin]),
+            "min_intensity": np.min(self.moving_transformed) * 65535
+            - np.min(self.moving_source[self.mov_origin]),
+            "max_intensity": np.max(self.moving_transformed) * 65535
+            - np.max(self.moving_source[self.mov_origin]),
+            "1st_percentile": np.percentile(self.moving_transformed, 1) * 65535
+            - np.percentile(self.moving_source[self.mov_origin], 1),
+            "995th_percentile": np.percentile(self.moving_transformed, 99.5) * 65535
+            - np.percentile(self.moving_source[self.mov_origin], 99.5),
+        }
+
+        return change_fov_intensity_param_dict
+
+    def report_changes_in_coordinates_mapping(self) -> Tuple[bool, float]:
+        """
+        Report changes in beads (center of FOV) centroid coordinates before and after transform. A good transform will
+        reduce the difference in distances, or at least not increase too much (thresh=5), between transformed_mov_beads and
+        ref_beads than mov_beads and ref_beads. A bad transform will increase the difference in distances between
+        transformed_mov_beads and ref_beads.
+        """
+
+        if self.ref_mov_coor_dict is None:
+            log.error("Error: ref_mov_coor_dict is missing for qc")
+            raise Exception("Error: ref_mov_coor_dict is missing for qc")
+            return (False, 0)
+        if self.tform is None:
+            log.error("Error: tform is missing for qc")
+            raise Exception("Error: tform is missing for qc")
+            return (False, 0)
+        if self.reference is None:
+            log.error("Error: reference raw image is missing for qc")
+            raise Exception("Error: reference raw image is missing for qc")
+            return (False, 0)
+
+        transform_qc = False
+        mov_coors = list(self.ref_mov_coor_dict.values())
+        ref_coors = list(self.ref_mov_coor_dict.keys())
+        mov_transformed_coors = self.tform(mov_coors)
+
+        dist_before_list = []
+        dist_after_list = []
+        for bead in range(0, len(mov_coors)):
+            dist_before = distance.euclidean(mov_coors[bead], ref_coors[bead])
+            dist_after = distance.euclidean(
+                mov_transformed_coors[bead], ref_coors[bead]
+            )
+            dist_before_list.append(dist_before)
+            dist_after_list.append(dist_after)
+
+        # filter center beads only
+        y_size = 360
+        x_size = 536
+
+        y_lim = (
+            int(self.reference[self.ref_origin].shape[0] / 2 - y_size / 2),
+            int(self.reference[self.ref_origin].shape[0] / 2 + y_size / 2),
+        )
+        x_lim = (
+            int(self.reference[self.ref_origin].shape[1] / 2 - x_size / 2),
+            int(self.reference[self.ref_origin].shape[1] / 2 + x_size / 2),
+        )
+
+        dist_before_center = []
+        dist_after_center = []
+        for bead in range(0, len(mov_coors)):
+            if (y_lim[1] > mov_coors[bead][0]) & (mov_coors[bead][0] > y_lim[0]):
+                if (x_lim[1] > mov_coors[bead][1]) & (mov_coors[bead][1] > x_lim[0]):
+                    dist_before_center.append(
+                        distance.euclidean(mov_coors[bead], ref_coors[bead])
+                    )
+                    dist_after_center.append(
+                        distance.euclidean(mov_transformed_coors[bead], ref_coors[bead])
+                    )
+        average_before_center = sum(dist_before_center) / len(dist_before_center)
+        average_after_center = sum(dist_after_center) / len(dist_after_center)
+
+        if (average_after_center - average_before_center) < 5:
+            transform_qc = True
+
+        return transform_qc, (average_after_center - average_before_center)
+
+    def report_changes_in_mse(self) -> Tuple[bool, float]:
+        """
+        Report changes in normalized root mean-squared-error value before and after transform, post-segmentation.
+        :return:
+            qc: A boolean to indicate if it passed (True) or failed (False) qc
+            diff_mse: Difference in mean squared error
+        """
+        qc = False
+
+        mse_before = metrics.mean_squared_error(self.reference_seg, self.moving_seg)
+        mse_after = metrics.mean_squared_error(
+            self.reference_seg, self.moving_seg_transformed
+        )
+
+        diff_mse = mse_after - mse_before
+        if diff_mse <= 0:
+            qc = True
+
+        return qc, diff_mse

--- a/camera_alignment_core/alignment_utils/alignment_qc.py
+++ b/camera_alignment_core/alignment_utils/alignment_qc.py
@@ -59,7 +59,6 @@ class AlignmentQC:
     def report_full_metrics(
         self,
     ) -> Dict[str, Optional[object]]:
-
         missing = self.check_all_defined()
         if missing is not None:
             log.error(

--- a/camera_alignment_core/alignment_utils/ring_alignment.py
+++ b/camera_alignment_core/alignment_utils/ring_alignment.py
@@ -74,10 +74,10 @@ class RingAlignment:
             # reject beads that are matched to 'false' beads or outside threshold
             if mov_bead >= num_mov or C[ref_bead, mov_bead] > max_cost:
                 continue
-            if ref_bead + 1 not in updated_ref_peak_dict.keys():
-                continue
-            if mov_bead + 1 not in updated_mov_peak_dict.keys():
-                continue
+            # if ref_bead + 1 not in updated_ref_peak_dict.keys():
+            #     continue
+            # if mov_bead + 1 not in updated_mov_peak_dict.keys():
+            #     continue
 
             ref_mov_coor_dict.update(
                 {

--- a/camera_alignment_core/alignment_utils/ring_alignment.py
+++ b/camera_alignment_core/alignment_utils/ring_alignment.py
@@ -1,14 +1,18 @@
 from collections import OrderedDict
+from distutils import dist
 import logging
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List
 
 import numpy as np
 import pandas as pd
-from scipy.optimize import linear_sum_assignment
-from scipy.spatial import distance
+from scipy.spatial import distance, KDTree
 from skimage import transform as tf
+from sklearn.neighbors import NearestNeighbors
+from scipy.optimize import linprog
+from scipy.optimize import linear_sum_assignment as linsum
 
 from ..constants import LOGGER_NAME
+from ..exception import AlignmentUnsuccessful
 from .alignment_info import AlignmentInfo
 
 log = logging.getLogger(LOGGER_NAME)
@@ -27,6 +31,105 @@ class RingAlignment:
         self.mov_rings_props = mov_rings_props
         self.mov_cross_label = mov_cross_label
 
+    # def assign_ref_to_mov_old(
+    #     self,
+    #     updated_ref_peak_dict: Dict[int, Tuple[int, int]],
+    #     updated_mov_peak_dict: Dict[int, Tuple[int, int]],
+    # ) -> Dict[Tuple[int, int], Tuple[int, int]]:
+    #     """
+    #     Assigns beads from moving image to reference image using
+    #     linear_sum_assignment to reduce the distance between the same bead on
+    #     the separate channels. In case where there is more beads in one channel
+    #     than the other, this method will throw off the extra bead that cannot
+    #     be assigned to one, single bead on the other image.
+
+    #     :param updated_ref_peak_dict: A dictionary
+    #         ({bead_number: (coor_y, coor_x)}) from reference beads
+    #     :param updated_mov_peak_dict:  A dictionary
+    #         ({bead_number: (coor_y, coor_x)}) from moving beads
+    #     :return:
+    #         ref_mov_coor_dict: A dictionary mapping the reference bead coordinates and moving bead coordinates
+    #     """
+    #     match_dict, weight_dict, cost_dict, max_cost = self.pos_bead_matches(updated_ref_peak_dict, updated_mov_peak_dict)
+    #     edges = []
+    #     weights = []
+    #     costs = []
+    #     positions = []
+    #     total_matches = 0
+    #     for idx_ref in match_dict.keys():
+    #         weight_group = []
+    #         edge_group = []
+    #         pos_group = []
+            
+    #         for i, idx_mov in enumerate(match_dict[idx_ref]):
+    #             edge_group.append((idx_ref, idx_mov))
+    #             weight_group.append(weight_dict[idx_ref][i])
+    #             pos_group.append(total_matches)
+    #             costs.append(cost_dict[idx_ref][i])
+    #             total_matches += 1
+            
+    #         edges.append((idx_ref, None))
+    #         weight_group.append(0.1)
+    #         costs.append(max_cost * 1.1)
+    #         pos_group.append(total_matches)
+    #         total_matches += 1
+            
+    #         weights.append(weight_group)
+    #         positions.append(pos_group)
+            
+    #     A_eq = []
+    #     for weight_group, pos_group in zip(weights, positions):
+    #         row = [0] * total_matches
+    #         for weight, postion in zip(weight_group, pos_group):
+    #             row[postion] = weight
+    #         A_eq.append(row)
+                
+    #     methods = ['highs','interior-point', 'simplex', 'highs-ipm']
+    #     b_eq = [1]*len(A_eq)
+    #     # print(np.array(A_eq).shape)
+    #     for method in methods:
+    #         result = linprog(
+    #             c=costs,
+    #             A_eq=A_eq,
+    #             b_eq=b_eq,
+    #             bounds=(0., 1.),
+    #             method=method,
+    #         )
+
+    #         if result.success:
+    #             break
+    #     if not result.success:
+    #         import pandas as pd
+    #         pd.DataFrame(np.array(A_eq)).to_csv('A.csv')
+    #         pd.DataFrame(np.array(result.x)).to_csv('x.csv')
+    #         pd.DataFrame(np.array(costs)).to_csv('cost.csv')
+    #         pd.DataFrame([str(e) for e in edges]).to_csv('edges.csv')
+    #         raise Exception()
+            
+    #     # import pdb; pdb.set_trace()
+            
+    #     matches = []
+    #     dists = []
+    #     for row in A_eq:
+    #         region = np.where(np.array(row)>0, result.x, np.zeros_like(result.x))
+    #         index = np.argmax(region).tolist()
+    #         matches.append(edges[index])
+    #         dists.append(costs[index])
+    #     print('max distance: ' + str(max(dists)))
+
+    #     ref_mov_coor_dict = {}
+    #     for ref_bead, mov_bead in matches:
+    #         if mov_bead is None:
+    #             continue
+    #         ref_mov_coor_dict.update(
+    #             {
+    #                 updated_ref_peak_dict[ref_bead]: 
+    #                     updated_mov_peak_dict[mov_bead]
+    #             }
+    #         )
+
+    #     return ref_mov_coor_dict
+    
     def assign_ref_to_mov(
         self,
         updated_ref_peak_dict: Dict[int, Tuple[int, int]],
@@ -46,27 +149,104 @@ class RingAlignment:
         :return:
             ref_mov_coor_dict: A dictionary mapping the reference bead coordinates and moving bead coordinates
         """
-        updated_ref_peak = list(OrderedDict(updated_ref_peak_dict).items())
-        updated_mov_peak = list(OrderedDict(updated_mov_peak_dict).items())
-
-        dist_tx = np.zeros((len(updated_ref_peak), len(updated_mov_peak)))
-        for i, (bead_ref, coor_ref) in enumerate(updated_ref_peak):
-            for j, (bead_mov, coor_mov) in enumerate(updated_mov_peak):
-                dist_tx[i, j] = distance.euclidean(coor_ref, coor_mov)
-
-        ref_ind, mov_ind = linear_sum_assignment(dist_tx)
+        match_dict, weight_dict, cost_dict, max_cost = self.pos_bead_matches(updated_ref_peak_dict, updated_mov_peak_dict)
+        num_ref = int(max(updated_ref_peak_dict.keys()))
+        num_mov = int(max(updated_mov_peak_dict.keys()))
+        C = np.ones((num_ref, num_ref + num_mov)) * (max_cost * 5)
+        
+        edges = []
+        for ref_bead in updated_ref_peak_dict.keys():
+            if ref_bead in match_dict.keys():
+                for mov_bead, cost in zip(match_dict[ref_bead], cost_dict[ref_bead]):
+                    C[int(ref_bead)-1, int(mov_bead)-1] = cost
+            C[int(ref_bead)-1, int(ref_bead+num_mov-1)] = max_cost * 1.1
+        pd.DataFrame(np.array(C)).to_csv('C.csv')
+        ref_matches, mov_matches = linsum(C)
+        pd.DataFrame([ref_matches, mov_matches]).to_csv('matches.csv')
 
         ref_mov_coor_dict = {}
-        for num_bead in range(0, len(ref_ind)):
-            ref_mov_coor_dict.update(
-                {
-                    updated_ref_peak[ref_ind[num_bead]][1]: updated_mov_peak[
-                        mov_ind[num_bead]
-                    ][1]
-                }
-            )
-
+        for ref_bead, mov_bead in zip(ref_matches, mov_matches):
+            if mov_bead >= num_mov or C[ref_bead, mov_bead] > max_cost:
+                continue
+            if ref_bead+1 not in updated_ref_peak_dict.keys():
+                continue
+            if mov_bead+1 not in updated_mov_peak_dict.keys():
+                continue
+            try:
+                ref_mov_coor_dict.update(
+                    {
+                        updated_ref_peak_dict[ref_bead+1]: 
+                            updated_mov_peak_dict[mov_bead+1]
+                    }
+                )
+            except:
+                import pdb; pdb.set_trace()
         return ref_mov_coor_dict
+    
+    def pos_bead_matches(
+        self,
+        ref_peak_dict: Dict[int, Tuple[int, int]],
+        mov_peak_dict: Dict[int, Tuple[int, int]],
+    ) -> Tuple[Dict[int, List[int]], Dict[int, int], Dict[int, int], int]:
+        """
+        Constrain ring matching problem by identifying which rings in the 
+        moving image are closer to a given reference image ring than the 
+        distance between rows/columns of rings. The threshold distance is
+        found by computing the median distance between rings and their 4
+        nearest neighbors in the reference image.
+        
+        :param ref_peak_dict:  A dictionary
+            ({bead_number: (coor_y, coor_x)}) from reference beads
+        :param mov_peak_dict:  A dictionary
+            ({bead_number: (coor_y, coor_x)}) from moving beads
+        :return:
+            match_dict: A dictionary mapping the reference bead numbers 
+                and moving bead numbers within the threshold distance
+            weight_dict: A dictionary for weight between a reference bead 
+                numbers and matching moving beads for matchingS
+            cost_dict: A dictionary mapping distance between a 
+                reference bead numbers and matching moving beads
+            thresh_dist: The threshold distance calculated
+        """
+        neigh = NearestNeighbors(n_neighbors=4)
+        neigh.fit([coors for coors in ref_peak_dict.values()])
+        mean_dist = []
+        for coor in ref_peak_dict.values():
+            dist, _ = neigh.kneighbors([coor], n_neighbors=4)
+            mean_dist.append(dist)
+        
+        thresh_dist = np.median(mean_dist) * 0.8
+        
+                        
+        tree_ref = KDTree(np.array([coors for coors in ref_peak_dict.values()]))
+        tree_mov = KDTree(np.array([coors for coors in mov_peak_dict.values()]))
+        neigh = tree_ref.query_ball_tree(tree_mov, thresh_dist)
+        
+        match_dict = {}
+        weight_dict = {}
+        cost_dict = {}
+        ref_beads = list(ref_peak_dict.keys())
+        mov_beads = list(mov_peak_dict.keys())
+        for idx_ref, idxs_mov in enumerate(neigh):
+            matches = []
+            weights = []
+            costs = []
+            for idx_mov in idxs_mov:
+                matches.append(ref_beads[idx_mov])
+                dist = distance.euclidean(ref_peak_dict[ref_beads[idx_ref]], mov_peak_dict[mov_beads[idx_mov]])
+                w = 1-dist/thresh_dist
+                if w > 0.8:
+                    w = 1
+                # elif w < 0.2:
+                #     w = 0.2
+                weights.append(w)
+                costs.append(dist + 0.001)
+            
+            match_dict[ref_beads[idx_ref]] = matches
+            weight_dict[ref_beads[idx_ref]] = weights
+            cost_dict[ref_beads[idx_ref]] = costs
+        
+        return match_dict, weight_dict, cost_dict, thresh_dist
 
     def rings_coor_dict(
         self, props: pd.DataFrame, cross_label: int
@@ -114,6 +294,7 @@ class RingAlignment:
 
         # match reference and moving beads
         ref_mov_coor_dict = self.assign_ref_to_mov(ref_centroid_dict, mov_centroid_dict)
+        # print(ref_mov_coor_dict)
 
         # yx to xy coordinates
         rev_coor_dict = self.change_coor_system(ref_mov_coor_dict)

--- a/camera_alignment_core/alignment_utils/ring_alignment.py
+++ b/camera_alignment_core/alignment_utils/ring_alignment.py
@@ -117,9 +117,9 @@ class RingAlignment:
             mean_dist.append(dist)
 
         thresh_dist = np.median(mean_dist) * 0.9
-        
+
         offset = self.calc_cross_offset()
-        offset_mag = sqrt(offset[0]**2 + offset[1]**2)
+        offset_mag = sqrt(offset[0] ** 2 + offset[1] ** 2)
         if offset_mag > thresh_dist:
             offset = (0, 0)
 
@@ -139,8 +139,13 @@ class RingAlignment:
             for idx_mov in idxs_mov:
                 matches.append(mov_beads[idx_mov])
                 dist = distance.euclidean(
-                    ref_peak_dict[ref_beads[idx_ref]], 
-                    tuple([m-o for m, o in zip(mov_peak_dict[mov_beads[idx_mov]],offset)])
+                    ref_peak_dict[ref_beads[idx_ref]],
+                    tuple(
+                        [
+                            m - o
+                            for m, o in zip(mov_peak_dict[mov_beads[idx_mov]], offset)
+                        ]
+                    ),
                 )
                 costs.append(dist + 0.001)
 
@@ -148,20 +153,26 @@ class RingAlignment:
             cost_dict[ref_beads[idx_ref]] = costs
 
         return match_dict, cost_dict, thresh_dist
-    
+
     def calc_cross_offset(self):
         """
         Estimate image offset by calculating the distance between the centroids
         of the cross in the reference and moving images.
         """
-        ref_cross = self.ref_rings_props[self.ref_rings_props["label"] == self.ref_cross_label]
-        mov_cross = self.mov_rings_props[self.mov_rings_props["label"] == self.mov_cross_label]
-        
-        offset = np.array([
-            mov_cross["centroid-0"].values[0] - ref_cross["centroid-0"].values[0],
-            mov_cross["centroid-1"].values[0] - ref_cross["centroid-1"].values[0]
-        ])
-        
+        ref_cross = self.ref_rings_props[
+            self.ref_rings_props["label"] == self.ref_cross_label
+        ]
+        mov_cross = self.mov_rings_props[
+            self.mov_rings_props["label"] == self.mov_cross_label
+        ]
+
+        offset = np.array(
+            [
+                mov_cross["centroid-0"].values[0] - ref_cross["centroid-0"].values[0],
+                mov_cross["centroid-1"].values[0] - ref_cross["centroid-1"].values[0],
+            ]
+        )
+
         return offset
 
     def rings_coor_dict(

--- a/camera_alignment_core/alignment_utils/ring_alignment.py
+++ b/camera_alignment_core/alignment_utils/ring_alignment.py
@@ -31,105 +31,6 @@ class RingAlignment:
         self.mov_rings_props = mov_rings_props
         self.mov_cross_label = mov_cross_label
 
-    # def assign_ref_to_mov_old(
-    #     self,
-    #     updated_ref_peak_dict: Dict[int, Tuple[int, int]],
-    #     updated_mov_peak_dict: Dict[int, Tuple[int, int]],
-    # ) -> Dict[Tuple[int, int], Tuple[int, int]]:
-    #     """
-    #     Assigns beads from moving image to reference image using
-    #     linear_sum_assignment to reduce the distance between the same bead on
-    #     the separate channels. In case where there is more beads in one channel
-    #     than the other, this method will throw off the extra bead that cannot
-    #     be assigned to one, single bead on the other image.
-
-    #     :param updated_ref_peak_dict: A dictionary
-    #         ({bead_number: (coor_y, coor_x)}) from reference beads
-    #     :param updated_mov_peak_dict:  A dictionary
-    #         ({bead_number: (coor_y, coor_x)}) from moving beads
-    #     :return:
-    #         ref_mov_coor_dict: A dictionary mapping the reference bead coordinates and moving bead coordinates
-    #     """
-    #     match_dict, weight_dict, cost_dict, max_cost = self.pos_bead_matches(updated_ref_peak_dict, updated_mov_peak_dict)
-    #     edges = []
-    #     weights = []
-    #     costs = []
-    #     positions = []
-    #     total_matches = 0
-    #     for idx_ref in match_dict.keys():
-    #         weight_group = []
-    #         edge_group = []
-    #         pos_group = []
-            
-    #         for i, idx_mov in enumerate(match_dict[idx_ref]):
-    #             edge_group.append((idx_ref, idx_mov))
-    #             weight_group.append(weight_dict[idx_ref][i])
-    #             pos_group.append(total_matches)
-    #             costs.append(cost_dict[idx_ref][i])
-    #             total_matches += 1
-            
-    #         edges.append((idx_ref, None))
-    #         weight_group.append(0.1)
-    #         costs.append(max_cost * 1.1)
-    #         pos_group.append(total_matches)
-    #         total_matches += 1
-            
-    #         weights.append(weight_group)
-    #         positions.append(pos_group)
-            
-    #     A_eq = []
-    #     for weight_group, pos_group in zip(weights, positions):
-    #         row = [0] * total_matches
-    #         for weight, postion in zip(weight_group, pos_group):
-    #             row[postion] = weight
-    #         A_eq.append(row)
-                
-    #     methods = ['highs','interior-point', 'simplex', 'highs-ipm']
-    #     b_eq = [1]*len(A_eq)
-    #     # print(np.array(A_eq).shape)
-    #     for method in methods:
-    #         result = linprog(
-    #             c=costs,
-    #             A_eq=A_eq,
-    #             b_eq=b_eq,
-    #             bounds=(0., 1.),
-    #             method=method,
-    #         )
-
-    #         if result.success:
-    #             break
-    #     if not result.success:
-    #         import pandas as pd
-    #         pd.DataFrame(np.array(A_eq)).to_csv('A.csv')
-    #         pd.DataFrame(np.array(result.x)).to_csv('x.csv')
-    #         pd.DataFrame(np.array(costs)).to_csv('cost.csv')
-    #         pd.DataFrame([str(e) for e in edges]).to_csv('edges.csv')
-    #         raise Exception()
-            
-    #     # import pdb; pdb.set_trace()
-            
-    #     matches = []
-    #     dists = []
-    #     for row in A_eq:
-    #         region = np.where(np.array(row)>0, result.x, np.zeros_like(result.x))
-    #         index = np.argmax(region).tolist()
-    #         matches.append(edges[index])
-    #         dists.append(costs[index])
-    #     print('max distance: ' + str(max(dists)))
-
-    #     ref_mov_coor_dict = {}
-    #     for ref_bead, mov_bead in matches:
-    #         if mov_bead is None:
-    #             continue
-    #         ref_mov_coor_dict.update(
-    #             {
-    #                 updated_ref_peak_dict[ref_bead]: 
-    #                     updated_mov_peak_dict[mov_bead]
-    #             }
-    #         )
-
-    #     return ref_mov_coor_dict
-    
     def assign_ref_to_mov(
         self,
         updated_ref_peak_dict: Dict[int, Tuple[int, int]],
@@ -149,104 +50,94 @@ class RingAlignment:
         :return:
             ref_mov_coor_dict: A dictionary mapping the reference bead coordinates and moving bead coordinates
         """
-        match_dict, weight_dict, cost_dict, max_cost = self.pos_bead_matches(updated_ref_peak_dict, updated_mov_peak_dict)
+        # calculate potential bead matches using nearest neighbors
+        match_dict, cost_dict, max_cost = self.pos_bead_matches(
+            updated_ref_peak_dict, updated_mov_peak_dict
+        )
         num_ref = int(max(updated_ref_peak_dict.keys()))
         num_mov = int(max(updated_mov_peak_dict.keys()))
+
+        # construct cost map for linear sum assignment
         C = np.ones((num_ref, num_ref + num_mov)) * (max_cost * 5)
-        
-        edges = []
         for ref_bead in updated_ref_peak_dict.keys():
             if ref_bead in match_dict.keys():
                 for mov_bead, cost in zip(match_dict[ref_bead], cost_dict[ref_bead]):
-                    C[int(ref_bead)-1, int(mov_bead)-1] = cost
-            C[int(ref_bead)-1, int(ref_bead+num_mov-1)] = max_cost * 1.1
-        pd.DataFrame(np.array(C)).to_csv('C.csv')
-        ref_matches, mov_matches = linsum(C)
-        pd.DataFrame([ref_matches, mov_matches]).to_csv('matches.csv')
+                    C[int(ref_bead) - 1, int(mov_bead) - 1] = cost
+            C[int(ref_bead) - 1, int(ref_bead + num_mov - 1)] = max_cost * 1.1
 
+        # perform optimization
+        ref_matches, mov_matches = linsum(C)
+
+        # assign matched beads to output dictionary
         ref_mov_coor_dict = {}
         for ref_bead, mov_bead in zip(ref_matches, mov_matches):
             if mov_bead >= num_mov or C[ref_bead, mov_bead] > max_cost:
                 continue
-            if ref_bead+1 not in updated_ref_peak_dict.keys():
-                continue
-            if mov_bead+1 not in updated_mov_peak_dict.keys():
-                continue
-            try:
-                ref_mov_coor_dict.update(
-                    {
-                        updated_ref_peak_dict[ref_bead+1]: 
-                            updated_mov_peak_dict[mov_bead+1]
-                    }
-                )
-            except:
-                import pdb; pdb.set_trace()
+            ref_mov_coor_dict.update(
+                {
+                    updated_ref_peak_dict[ref_bead + 1]: updated_mov_peak_dict[
+                        mov_bead + 1
+                    ]
+                }
+            )
         return ref_mov_coor_dict
-    
+
     def pos_bead_matches(
         self,
         ref_peak_dict: Dict[int, Tuple[int, int]],
         mov_peak_dict: Dict[int, Tuple[int, int]],
-    ) -> Tuple[Dict[int, List[int]], Dict[int, int], Dict[int, int], int]:
+    ) -> Tuple[Dict[int, List[int]], Dict[int, int], int]:
         """
-        Constrain ring matching problem by identifying which rings in the 
-        moving image are closer to a given reference image ring than the 
+        Constrain ring matching problem by identifying which rings in the
+        moving image are closer to a given reference image ring than the
         distance between rows/columns of rings. The threshold distance is
         found by computing the median distance between rings and their 4
         nearest neighbors in the reference image.
-        
+
         :param ref_peak_dict:  A dictionary
             ({bead_number: (coor_y, coor_x)}) from reference beads
         :param mov_peak_dict:  A dictionary
             ({bead_number: (coor_y, coor_x)}) from moving beads
         :return:
-            match_dict: A dictionary mapping the reference bead numbers 
+            match_dict: A dictionary mapping the reference bead numbers
                 and moving bead numbers within the threshold distance
-            weight_dict: A dictionary for weight between a reference bead 
-                numbers and matching moving beads for matchingS
-            cost_dict: A dictionary mapping distance between a 
+            cost_dict: A dictionary mapping distance between a
                 reference bead numbers and matching moving beads
             thresh_dist: The threshold distance calculated
         """
+        # determine threshold distance using median distance to nearest
+        # four neighbours
         neigh = NearestNeighbors(n_neighbors=4)
         neigh.fit([coors for coors in ref_peak_dict.values()])
         mean_dist = []
         for coor in ref_peak_dict.values():
             dist, _ = neigh.kneighbors([coor], n_neighbors=4)
             mean_dist.append(dist)
-        
+
         thresh_dist = np.median(mean_dist) * 0.8
-        
-                        
+
+        # calculate bead neighborhoods
         tree_ref = KDTree(np.array([coors for coors in ref_peak_dict.values()]))
         tree_mov = KDTree(np.array([coors for coors in mov_peak_dict.values()]))
         neigh = tree_ref.query_ball_tree(tree_mov, thresh_dist)
-        
+
+        # assign matching moving beads and distances to each reference bead
         match_dict = {}
-        weight_dict = {}
         cost_dict = {}
         ref_beads = list(ref_peak_dict.keys())
         mov_beads = list(mov_peak_dict.keys())
         for idx_ref, idxs_mov in enumerate(neigh):
             matches = []
-            weights = []
             costs = []
             for idx_mov in idxs_mov:
                 matches.append(ref_beads[idx_mov])
-                dist = distance.euclidean(ref_peak_dict[ref_beads[idx_ref]], mov_peak_dict[mov_beads[idx_mov]])
-                w = 1-dist/thresh_dist
-                if w > 0.8:
-                    w = 1
-                # elif w < 0.2:
-                #     w = 0.2
-                weights.append(w)
+                dist = distance.euclidean(
+                    ref_peak_dict[ref_beads[idx_ref]], mov_peak_dict[mov_beads[idx_mov]]
+                )
                 costs.append(dist + 0.001)
-            
-            match_dict[ref_beads[idx_ref]] = matches
-            weight_dict[ref_beads[idx_ref]] = weights
             cost_dict[ref_beads[idx_ref]] = costs
-        
-        return match_dict, weight_dict, cost_dict, thresh_dist
+
+        return match_dict, cost_dict, thresh_dist
 
     def rings_coor_dict(
         self, props: pd.DataFrame, cross_label: int

--- a/camera_alignment_core/alignment_utils/ring_alignment.py
+++ b/camera_alignment_core/alignment_utils/ring_alignment.py
@@ -74,10 +74,6 @@ class RingAlignment:
             # reject beads that are matched to 'false' beads or outside threshold
             if mov_bead >= num_mov or C[ref_bead, mov_bead] > max_cost:
                 continue
-            # if ref_bead + 1 not in updated_ref_peak_dict.keys():
-            #     continue
-            # if mov_bead + 1 not in updated_mov_peak_dict.keys():
-            #     continue
 
             ref_mov_coor_dict.update(
                 {

--- a/camera_alignment_core/alignment_utils/segment_rings.py
+++ b/camera_alignment_core/alignment_utils/segment_rings.py
@@ -133,11 +133,7 @@ class SegmentRings:
                 ):
                     break
 
-        # try:
         _, props, cross_label = self.filter_center_cross(label_for_cross)
-        # except:
-        #     from skimage.io import imsave
-        #     import pdb; pdb.set_trace()
 
         seg_cross = label_for_cross == cross_label
 
@@ -322,10 +318,6 @@ class SegmentRings:
                 minArea=minArea,
             )
 
-        # try:
         _, props_df, cross_label = self.filter_center_cross(label_rings)
-        # except:
-        #     from skimage.io import imsave
-        #     import pdb; pdb.set_trace()
 
         return seg_rings, label_rings, props_df, cross_label

--- a/camera_alignment_core/alignment_utils/segment_rings.py
+++ b/camera_alignment_core/alignment_utils/segment_rings.py
@@ -133,7 +133,13 @@ class SegmentRings:
                 ):
                     break
 
+        # try:
         _, props, cross_label = self.filter_center_cross(label_for_cross)
+        # except:
+        #     from skimage.io import imsave
+        #     import pdb; pdb.set_trace()
+
+        
         seg_cross = label_for_cross == cross_label
 
         return seg_cross, props
@@ -243,6 +249,7 @@ class SegmentRings:
             label_seg, properties=["label", "area", "centroid"]
         )
         props_df = pd.DataFrame(props)
+        
         cross_label = props_df.loc[
             (props_df["area"] == props_df["area"].max()), "label"
         ].values.tolist()[0]
@@ -315,7 +322,11 @@ class SegmentRings:
                 num_beads=num_beads,
                 minArea=minArea,
             )
-
+            
+        # try:
         _, props_df, cross_label = self.filter_center_cross(label_rings)
+        # except:
+        #     from skimage.io import imsave
+        #     import pdb; pdb.set_trace()
 
         return seg_rings, label_rings, props_df, cross_label

--- a/camera_alignment_core/alignment_utils/segment_rings.py
+++ b/camera_alignment_core/alignment_utils/segment_rings.py
@@ -139,7 +139,6 @@ class SegmentRings:
         #     from skimage.io import imsave
         #     import pdb; pdb.set_trace()
 
-        
         seg_cross = label_for_cross == cross_label
 
         return seg_cross, props
@@ -249,7 +248,7 @@ class SegmentRings:
             label_seg, properties=["label", "area", "centroid"]
         )
         props_df = pd.DataFrame(props)
-        
+
         cross_label = props_df.loc[
             (props_df["area"] == props_df["area"].max()), "label"
         ].values.tolist()[0]
@@ -322,7 +321,7 @@ class SegmentRings:
                 num_beads=num_beads,
                 minArea=minArea,
             )
-            
+
         # try:
         _, props_df, cross_label = self.filter_center_cross(label_rings)
         # except:

--- a/camera_alignment_core/exception/__init__.py
+++ b/camera_alignment_core/exception/__init__.py
@@ -4,3 +4,6 @@ class IncompatibleImageException(BaseException):
 
 class UnsupportedMagnification(BaseException):
     pass
+
+class AlignmentUnsuccessful(BaseException):
+    pass

--- a/camera_alignment_core/exception/__init__.py
+++ b/camera_alignment_core/exception/__init__.py
@@ -5,5 +5,6 @@ class IncompatibleImageException(BaseException):
 class UnsupportedMagnification(BaseException):
     pass
 
+
 class AlignmentUnsuccessful(BaseException):
     pass

--- a/camera_alignment_core/tests/alignment_utils/test_segment_rings.py
+++ b/camera_alignment_core/tests/alignment_utils/test_segment_rings.py
@@ -71,7 +71,6 @@ class TestSegmentRings:
 
         square_error = []
         for GT_coor, seg_coor in coor_dict.items():
-
             square_error.append(
                 math.sqrt(
                     (GT_coor[0] - seg_coor[0]) ** 2 + (GT_coor[1] - seg_coor[1]) ** 2

--- a/camera_alignment_core/tests/test_alignment_core.py
+++ b/camera_alignment_core/tests/test_alignment_core.py
@@ -50,7 +50,10 @@ class TestAlignmentCore:
         )
 
         # Act
-        (actual_alignment_matrix, _,) = generate_alignment_matrix(
+        (
+            actual_alignment_matrix,
+            _,
+        ) = generate_alignment_matrix(
             optical_control_image_data,
             reference_channel=2,  # TaRFP
             shift_channel=3,  # CMDRP
@@ -81,7 +84,10 @@ class TestAlignmentCore:
         )
 
         # Act
-        (actual_alignment_matrix, _,) = generate_alignment_matrix(
+        (
+            actual_alignment_matrix,
+            _,
+        ) = generate_alignment_matrix(
             optical_control_image_data,
             reference_channel=2,  # TaRFP
             shift_channel=3,  # CMDRP
@@ -107,14 +113,20 @@ class TestAlignmentCore:
         pixel_size_xy = optical_control_image.physical_pixel_sizes.X
 
         # Act
-        (alignment_matrix_1, _,) = generate_alignment_matrix(
+        (
+            alignment_matrix_1,
+            _,
+        ) = generate_alignment_matrix(
             optical_control_image_data,
             reference_channel=2,  # TaRFP
             shift_channel=3,  # CMDRP
             magnification=magnification,
             px_size_xy=pixel_size_xy,
         )
-        (alignment_matrix_2, _,) = generate_alignment_matrix(
+        (
+            alignment_matrix_2,
+            _,
+        ) = generate_alignment_matrix(
             optical_control_image_data,
             reference_channel=2,  # TaRFP
             shift_channel=3,  # CMDRP
@@ -147,7 +159,6 @@ class TestAlignmentCore:
         expectation_image_path: str,
         magnification: Magnification,
     ):
-
         # Arrange
         image, local_image_path = get_test_image(image_path)
         channel_info = channel_info_factory(local_image_path)
@@ -164,7 +175,10 @@ class TestAlignmentCore:
         # so assert the `X` property `is not None` before use in `generate_alignment_matrix`
         assert optical_control_image.physical_pixel_sizes.X is not None
 
-        (alignment_matrix, _,) = generate_alignment_matrix(
+        (
+            alignment_matrix,
+            _,
+        ) = generate_alignment_matrix(
             optical_control_image=optical_control_image_data,
             # TaRFP should have been used instead,
             # but H3342 was used as ref channel when ALIGNED_ZSD1_IMAGE_URL was created

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,5 +52,7 @@ html_theme = "furo"
 
 
 # -- Extensions ----------------------------------------------------------------
-napoleon_numpy_docstring = True  # https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
+napoleon_numpy_docstring = (
+    True  # https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
+)
 napoleon_google_docstring = False

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,9 @@ requirements = [
     "aicsimageio ~= 4.7",
     "aicspylibczi ~= 3.0.0",
     "numpy ~= 1.21",
-
     # v0.19.3 causes test failure for TestAlignmentCore::test_align_image
     "scikit-image == 0.19.2",
-    "scikit-learn == 1.3.1"
+    "scikit-learn == 1.3.1",
 ]
 
 dev_requirements = [
@@ -19,19 +18,14 @@ dev_requirements = [
     "mypy ~= 0.910",
     "pytest ~= 6.2.5",
     "pytest-raises ~= 0.11",
-
     # Dev workflow
     "pre-commit ~= 2.17.0",
-
     # Build
     "build == 0.7.0",
-
     # Version
     "bump2version ~= 1.0.1",
-
     # Publish
     "twine ~= 3.7.1",
-
     # Documentation generation
     "Sphinx ~= 4.4.0",
     "furo == 2022.1.2",  # Third-party theme (https://pradyunsg.me/furo/quickstart/)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ requirements = [
     "numpy ~= 1.21",
 
     # v0.19.3 causes test failure for TestAlignmentCore::test_align_image
-    "scikit-image == 0.19.2"
+    "scikit-image == 0.19.2",
+    "scikit-learn == 1.3.1"
 ]
 
 dev_requirements = [


### PR DESCRIPTION
This updates the algorithm used to align argolight beads to be robust against errors in bead segmentations. Previous implementation of the algorithm assumed that each bead is segmented in both reference and moving channels, but this is not the case in 20x fov's. This leads to the algorithm tries to find a match for every possible bead, even if it needs to match beads from different rows/columns, and the transformation matrix calculated as a result causes worse misalignment in applied images than before performing alignment. This occurred in ~15% of 20x fov's tested. This updated algorithm resolves this problem by allowing the matching algorithm to discard such poorly segmented beads instead, eliminating all alignment errors in the tested set of argolight images.