### PR TITLE
Feature/load alignment

### DIFF
--- a/camera_alignment_core/align.py
+++ b/camera_alignment_core/align.py
@@ -83,10 +83,15 @@ class Align:
             Which channel of `optical_control` to shift for generation of the alignment matrix.
             Relative to `reference_channel_index`.
             See `reference_channel_index` description for detail on what happens if this argument is not provided.
+        alignment_transform : Optional[AlignmentTransform]
+            Precomputed alignment transform to use for aligning images.
+            If provided, `optical_control` will be ignored.
         """
         if not alignment_transform:
             self._optical_control_path = pathlib.Path(optical_control)
-            assert self._optical_control_path.exists(), f"File not found: {optical_control}. If no alignment transform is provided you must include a path to the optical control image."
+            assert (
+                self._optical_control_path.exists()
+            ), f"File not found: {optical_control}. If no alignment transform is provided you must include a path to the optical control image."
             self._optical_control = AICSImage(optical_control)
 
         self._magnification = magnification
@@ -208,6 +213,7 @@ class Align:
         scenes: typing.List[int] = [],
         timepoints: typing.List[int] = [],
         crop_output: bool = True,
+        interpolation: int = 0,
     ) -> typing.List[AlignedImage]:
         """Align channels within `image` using similarity transform generated from the optical control image passed to
         this instance at construction. Scenes within `image` will be saved to their own image files once aligned.
@@ -233,6 +239,8 @@ class Align:
             Optional flag for toggling whether to crop aligned image according to standard dimensions
             for the magnification at which the image was acquired. Defaults to `True`, which means,
             "yes, crop the image."
+        interpolation : Optional[int]
+            Interpolation order to use when applying the alignment transform. Default is 0.
 
         Returns
         -------
@@ -250,16 +258,16 @@ class Align:
             aics_image.set_scene(scene)
 
             # Align timepoints within scene
-            processed_timepoints: typing.List[
-                numpy.typing.NDArray[numpy.uint16]
-            ] = list()
+            processed_timepoints: typing.List[numpy.typing.NDArray[numpy.uint16]] = (
+                list()
+            )
             timepoint_indices = (
                 timepoints if timepoints else range(0, aics_image.dims.T)
             )
             for timepoint in timepoint_indices:
                 image_slice = aics_image.get_image_data("CZYX", T=timepoint)
                 processed = align_image(
-                    image_slice, self.alignment_transform.matrix, channels_to_shift
+                    image_slice, self.alignment_transform.matrix, channels_to_shift, interpolation
                 )
                 if crop_output:
                     processed_timepoints.append(crop(processed, self._magnification))

--- a/camera_alignment_core/align.py
+++ b/camera_alignment_core/align.py
@@ -55,6 +55,7 @@ class Align:
         out_dir: typing.Union[str, pathlib.Path],
         reference_channel_index: typing.Optional[int] = None,
         shift_channel_index: typing.Optional[int] = None,
+        alignment_transform: typing.Optional[AlignmentTransform] = None,
     ) -> None:
         """Constructor.
 
@@ -83,8 +84,10 @@ class Align:
             Relative to `reference_channel_index`.
             See `reference_channel_index` description for detail on what happens if this argument is not provided.
         """
-        self._optical_control_path = pathlib.Path(optical_control)
-        self._optical_control = AICSImage(optical_control)
+        if not alignment_transform:
+            self._optical_control_path = pathlib.Path(optical_control)
+            assert self._optical_control_path.exists(), f"File not found: {optical_control}. If no alignment transform is provided you must include a path to the optical control image."
+            self._optical_control = AICSImage(optical_control)
 
         self._magnification = magnification
         self._out_dir = pathlib.Path(out_dir)
@@ -93,10 +96,14 @@ class Align:
         self._reference_channel_index = reference_channel_index
         self._shift_channel_index = shift_channel_index
 
-        self._alignment_matrix: typing.Optional[
-            numpy.typing.NDArray[numpy.float16]
-        ] = None
-        self._alignment_info: typing.Optional[AlignmentInfo] = None
+        if alignment_transform:
+            self._alignment_matrix = alignment_transform.matrix
+            self._alignment_info = alignment_transform.info
+        else:
+            self._alignment_matrix: typing.Optional[
+                numpy.typing.NDArray[numpy.float16]
+            ] = None
+            self._alignment_info: typing.Optional[AlignmentInfo] = None
 
     @property
     def alignment_transform(self) -> AlignmentTransform:

--- a/camera_alignment_core/alignment_core.py
+++ b/camera_alignment_core/alignment_core.py
@@ -105,6 +105,7 @@ def align_image(
     image: numpy.typing.NDArray[numpy.uint16],
     alignment_matrix: numpy.typing.NDArray[numpy.float16],
     channels_to_shift: List[int],
+    interpolation: int = 0,
 ) -> numpy.typing.NDArray[numpy.uint16]:
     """Align a CZYX `image` using `alignment_matrix`.
     Will only apply the `alignment_matrix` to image slices within the channels specified in
@@ -119,6 +120,8 @@ def align_image(
     channels_to_shift : List[int]
         Index positions of channels within `image` that should be shifted. N.b.: indices start at 0.
         E.g.: Specify [0, 2] to apply the alignment transform to channels at index positions 0 and 2 within `image`.
+    interpolation : int
+        Interpolation order to use when applying the alignment transform. Default is 0.
     """
     if not image.ndim == 4:
         raise IncompatibleImageException(
@@ -141,7 +144,7 @@ def align_image(
                 aligned_channel[z_index, :, :] = skimage.transform.warp(
                     unaligned_channel[z_index, :, :],
                     inverse_map=alignment_matrix,
-                    order=0, #3
+                    order=interpolation, #3
                     preserve_range=True,
                 )
             

--- a/camera_alignment_core/alignment_core.py
+++ b/camera_alignment_core/alignment_core.py
@@ -141,12 +141,15 @@ def align_image(
                 aligned_channel[z_index, :, :] = skimage.transform.warp(
                     unaligned_channel[z_index, :, :],
                     inverse_map=alignment_matrix,
-                    order=3,
+                    order=0, #3
                 )
             # skimage.transform.warp converts input image to the float range (0..1), so rescale to uint16
-            aligned_image[channel_index] = (
-                aligned_channel * numpy.iinfo(numpy.uint16).max
+            aligned_image[channel_index] = skimage.exposure.rescale_intensity(
+                aligned_channel, in_range=(0, 1), out_range=(0, numpy.iinfo(numpy.uint16).max)
             ).astype(numpy.uint16)
+            # aligned_image[channel_index] = (
+            #     aligned_channel * numpy.iinfo(numpy.uint16).max
+            # ).astype(numpy.uint16)
         else:
             log.debug("Skipping alignment for %s channel", channel_index)
             aligned_image[channel_index] = unaligned_channel

--- a/camera_alignment_core/alignment_core.py
+++ b/camera_alignment_core/alignment_core.py
@@ -142,14 +142,10 @@ def align_image(
                     unaligned_channel[z_index, :, :],
                     inverse_map=alignment_matrix,
                     order=0, #3
+                    preserve_range=True,
                 )
-            # skimage.transform.warp converts input image to the float range (0..1), so rescale to uint16
-            aligned_image[channel_index] = skimage.exposure.rescale_intensity(
-                aligned_channel, in_range=(0, 1), out_range=(0, numpy.iinfo(numpy.uint16).max)
-            ).astype(numpy.uint16)
-            # aligned_image[channel_index] = (
-            #     aligned_channel * numpy.iinfo(numpy.uint16).max
-            # ).astype(numpy.uint16)
+            
+            aligned_image[channel_index] =  aligned_channel
         else:
             log.debug("Skipping alignment for %s channel", channel_index)
             aligned_image[channel_index] = unaligned_channel

--- a/camera_alignment_core/alignment_utils/segment_rings.py
+++ b/camera_alignment_core/alignment_utils/segment_rings.py
@@ -207,11 +207,11 @@ class SegmentRings:
             seg = self.dot_2d_slice_by_slice_wrapper(img, s2_param)[0, :, :]
 
             remove_small = remove_small_objects(
-                seg > 0, min_size=minArea, connectivity=1, in_place=False
+                seg > 0, min_size=minArea, connectivity=1
             )
 
-            dilate = morphology.binary_dilation(remove_small, selem=morphology.disk(2))
-            seg_rings = morphology.binary_erosion(dilate, selem=morphology.disk(2))
+            dilate = morphology.binary_dilation(remove_small, footprint=morphology.disk(2))
+            seg_rings = morphology.binary_erosion(dilate, footprint=morphology.disk(2))
 
             seg = np.logical_or(seg_cross, seg_rings).astype(np.bool_)
             label = measure.label(seg).astype(np.uint16)

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import find_packages, setup
 requirements = [
     "aicsimageio ~= 4.7",
     "aicspylibczi ~= 3.0.0",
-    "numpy ~= 1.21",
+    "numpy",
     # v0.19.3 causes test failure for TestAlignmentCore::test_align_image
-    "scikit-image == 0.19.2",
-    "scikit-learn == 1.3.1",
+    "scikit-image ~= 0.21.0",
+    "scikit-learn ~= 1.3.1",
 ]
 
 dev_requirements = [


### PR DESCRIPTION
Key Features

- ability to initiate `Align()` class with a pre-generated `AlignmentTranform` object instead of a path to the optical control image and needing to recompute alignment every single time
- using nearest neighbor rather than bi-cubic interpolation when applying alignment transform to an image
- updating `scikit-image` version to 0.21 to use the `preserve_range` feature of `warp()`, removing need for manually correcting intensities after alignment
