### PR TITLE
try to resolve sphinx error by bumping version up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ dev_requirements = [
     # Publish
     "twine ~= 3.7.1",
     # Documentation generation
-    "Sphinx ~= 4.4.0",
+    "Sphinx ~= 5.0.0",
     "furo == 2022.1.2",  # Third-party theme (https://pradyunsg.me/furo/quickstart/)
     "m2r2 ~= 0.3.2",  # Sphinx extension for parsing README.md as reST and including in Sphinx docs
 ]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ dev_requirements = [
     "twine ~= 3.7.1",
     # Documentation generation
     "Sphinx ~= 5.0.0",
-    "furo == 2022.1.2",  # Third-party theme (https://pradyunsg.me/furo/quickstart/)
+    "furo == 2022.06.04",  # Third-party theme (https://pradyunsg.me/furo/quickstart/)
     "m2r2 ~= 0.3.2",  # Sphinx extension for parsing README.md as reST and including in Sphinx docs
 ]
 


### PR DESCRIPTION
The last PR didn't include fixes to handle the out-of-date documentation build.  These changes leave the build LESS out of date, but seem to run locally.  I didn't test this process on the last PR since I didn't know it existed.